### PR TITLE
视频和字幕整理规范: 增加 NC 多集数规范, 更新 NC 示例

### DIFF
--- a/视频和字幕整理规范.md
+++ b/视频和字幕整理规范.md
@@ -154,7 +154,7 @@
   |菜单 Menu<br />BD/DVD 播放选择菜单<br />|Menu<br />Menu_BDBOX/DVD/OVA/OAD|1. 对于通常分卷 BD, Menu 编号应当使用卷号, 同一卷有多个 Menu 时 (比如单碟多 Menu 或者一卷下有多碟), 在编号后加下划线进行第二轮编号, 如 Menu01_1<br />2. 特殊载体 (BDBOX/DVD/OVA/OAD) 的 Menu, 以 `Menu_载体` 作为开头, 然后再标记卷号, 如 Menu_OAD01<br />3. 如果是剧场版多碟或者只有 BDBOX 时, 此时没有卷的概念, 使用碟片号作为编号|
   |广告 Commercial Message (CM)<br />电视放送广告, 时长一般在 7s/15s/30s/45s 左右<br />|CM<br />TV-SPOT<br />CM Collection|合集使用 CM Collection 命名<br />
   |宣传片/预告片  Promotion Video (PV) / Trailer<br />一般时长在 1~2min 左右<br />|PV<br />Trailer<br />Teaser<br />Character PV<br />PV Collection|1. PV/Trailer/Teaser 一般来说难以直接区分, 可参考原盘菜单的写法, 如果菜单没有明确的英文默认直接使用 PV<br />2. 命名中不区分各种 PV 的变体, 一律命名为 PV, 只有角色 PV 可以单独命名<br />3. 合集使用 PV Collection 命名|
-  |无字特典 Non-Credit<br />无字 OP/ED: Non-Credit Opening/Ending<br />无字开场片段: Non-Credit Avant<br />无字正片: Non-Credit A Part/B Part|NCOP<br />NCED|1. 必须标注编号, 先按出场顺序来排序通用 OPED, 再根据集数来排序特殊集 OPED<br />2. 所有的特殊集 NC 特典必须标注集数, 写法为 `NC{类别}{编号}_EP{集数}`, 如 `NCOP03_EP02`<br />3. 整集 NC 版本一律写为 `集数(NC Ver.)`, 例如 `01(NC Ver.)`<br />4. 不强制要求区分 Avant 和 OP, 可以将 Avant 一律当做 OP 来命名|
+  |无字特典 Non-Credit<br />无字 OP/ED: Non-Credit Opening/Ending<br />无字开场片段: Non-Credit Avant<br />无字正片: Non-Credit A Part/B Part|NCOP<br />NCED<br />NC-Avant<br />NC-APart<br />NC-BPart|1. 必须标注编号, 先按出场顺序来排序通用 OPED, 再根据集数来排序特殊集 OPED<br />2. 所有的特殊集 NC 特典必须标注集数, 写法为 `NC{类别}{编号}_EP{集数}`, 如 `NCOP03_EP02`<br />3. 多集共用的特殊集 NC 特典应该标注所有相关集数: 连续多集使用 `-` 连接首尾集数, 例如 `EP04-06`; 间隔多集使用 `&` 连接所有集数, 例如 `EP07&10`<br />4. 整集 NC 版本一律写为 `集数(NC Ver.)`, 例如 `01(NC Ver.)`<br />5. 不强制要求区分 Avant 和 OP, 可以将 Avant 一律当做 OP 来命名|
   |音乐视频 Music Video<br />部分原盘菜单会将 MV 写为 PV, 注意与宣传片的 PV 进行区分|MV| |
   |真人特典 (节目、采访、舞台活动、制作花絮...) Program/Interview/Talk/Stage/Making...<br />对于这样的三次元长视频内容, 可以一概怼成 IV<br />|IV 或根据实际内容编写|根据实际内容编写时, 不要直接翻译成英文或转写为罗马音, 应当提取其中关键信息进行命名|
   |特典 Special (SP)<br />剩下的各种二次元类型可以全部归为这类|根据内容自定义|根据特典内容提取关键信息进行自定义命名<br />原则上禁止使用 SP 命名, 因为这样几乎不提供任何有价值的信息|
@@ -277,10 +277,12 @@
 [VCB-Studio] Kimi no Na wa. -your name.- [MV][Ma10p_1080p][x265_flac].mkv | 标准 MV 命名
 [VCB-Studio] THE ROLLING GIRLS [NCOP][Ma10p_1080p][x265_flac].mkv | 标准 NCOP, 只有一个时不写序号
 [VCB-Studio] Bungo Stray Dogs [NCOP02][Ma10p_1080p][x265_flac].mkv | 标准 NCOP, 有多个时依序排列
+[UHA-WINGS&VCB-Studio] EIGHTY SIX [NCOP01_EP01-03][Ma10p_1080p][x265_flac].mkv | 连续多集的 NCOP
 [VCB-Studio] Osomatsu-san [NCED01][Ma10p_1080p][x265_12flac].mkv | 标准 NCED, 这个例子确实封了 12 条 flac
-[VCB-Studio] Death Parade [NCED12][Ma10p_1080p][x265_flac].mkv | 专门某话的 NCED/OP 可以使用那一话的编号
-[VCB-Studio] Death Parade [NCED_EP12][Ma10p_1080p][x265_flac].mkv | 专门某话的 NCED/OP, 另一种表示法
-[VCB-Studio] Death Parade [NCED04_EP12][Ma10p_1080p][x265_flac].mkv | 专门某话的 NCED/OP, 还有很多种表示法
+[VCB-Studio] Death Parade [NCED04_EP12][Ma10p_1080p][x265_flac].mkv | 专门某话的 NCED/OP
+[VCB-Studio] Gakkou Gurashi! [NCED02_EP03&05][Ma10p_1080p][x265_flac].mkv | 跨集使用的 NCED
+[VCB-Studio] Ryuuou no Oshigoto! [NC-Avant02_EP12][Ma10p_1080p][x265_flac].mkv | 专门某话的 NC Avant, 不止一个 NC Avant
+[VCB-Studio] GOSICK [NC-BPart_EP24][Ma10p_1080p][x265_flac].mkv | 专门某话的 NC BPart
 [VCB-Studio] Re：Zero kara Hajimeru Isekai Seikatsu [PV01][Ma10p_1080p][x265_flac].mkv | 标准 PV 命名
 [VCB-Studio] Kimi no Na wa. -your name.- [Trailer01][Ma10p_1080p][x265_flac].mkv | 标准 Trailer 命名
 [VCB-Studio] Ajin The Movie [PV02][Ma10p_1080p][x265_2flac].mkv | 特典原则上不外挂 mka, 可能出现 2.0+5.1


### PR DESCRIPTION
This pull request updates the naming conventions for Non-Credit (NC) special features in the `视频和字幕整理规范.md` documentation, providing more precise rules for handling multi-episode and cross-episode cases. It also adds new examples to illustrate these conventions.

### Documentation improvements to NC feature naming:

* Clarified the rule for naming NC features when they span multiple consecutive episodes, specifying the use of `-` to connect episode ranges (e.g., `EP04-06`), and `&` for non-consecutive/cross episodes (e.g., `EP07&10`) in the naming format (`NC{类别}{编号}_EP{集数}`).

### Example updates:

* Added an example for a consecutive multi-episode NCOP: `[UHA-WINGS&VCB-Studio] EIGHTY SIX [NCOP01_EP01-03][Ma10p_1080p][x265_flac].mkv`.
* Added an example for a cross-episode NCED: `[VCB-Studio] Gakkou Gurashi! [NCED02_EP03&05][Ma10p_1080p][x265_flac].mkv`.
* Removed redundant and inconsistent NCED/OP examples, consolidating to a single, clear example for a specific episode NCED/OP (`[VCB-Studio] Death Parade [NCED04_EP12][Ma10p_1080p][x265_flac].mkv`).